### PR TITLE
fix - mocking python-periphery so it can work on rtd.org

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,8 +32,17 @@
 # ones.
 import os
 import sys
+from mock import Mock as MagicMock
 
 sys.path.insert(0, os.path.abspath('../../Python'))
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return MagicMock()
+
+MOCK_MODULES = ['periphery']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
The API didn't appear because `python-periphery` couldn't be loaded in RTD.