### PR TITLE
hotfix - fix mechanism for installing with or without su permissions

### DIFF
--- a/Install/README.md
+++ b/Install/README.md
@@ -1,6 +1,10 @@
 ## Installing
 
-For installing the DI_Sensors, enter the following command on your Raspberry Pi:
+For installing the DI_Sensors, enter one of the following 2 commands on your Raspberry Pi:
 ```
-sudo curl -kL dexterindustries.com/update_sensors | bash
+# for installing the python packages with root permissions (except anything else which will ran as root) run this
+sudo sh -c "curl -kL dexterindustries.com/update_gopigo3 | bash"
+
+# for installing the python packages with user permissions (except anything else which will ran as root) run this
+curl -kL dexterindustries.com/update_gopigo3 | bash
 ```

--- a/Install/update_sensors.sh
+++ b/Install/update_sensors.sh
@@ -27,14 +27,14 @@ else
 fi
 
 pushd $SENSOR_DIR/Python
-sudo python setup.py install
-sudo python3 setup.py install
+python setup.py install
+python3 setup.py install
 popd
 
 pushd $SENSOR_DIR/Python/di_sensors/DHT_Sensor
-sudo python setup.py install
-sudo python3 setup.py install
+python setup.py install
+python3 setup.py install
 popd
 
-sudo pip install python-periphery
-sudo pip3 install python-periphery
+pip install python-periphery
+pip3 install python-periphery

--- a/README.md
+++ b/README.md
@@ -19,9 +19,16 @@ The following Grove compatible devices are supported in Python:
 Installation
 ------------
 
-In order to quick install the `DI_Sensors` repository, open up a terminal and type the following command:
+In order to quick install the `DI_Sensors` repository, open up a terminal and type one of the 2 following commands:
+
+1. For installing the python packages of the `DI_Sensors` with root privileges (except any other settings that can come with), use the following command:
 ```
-sudo curl -kL dexterindustries.com/update_sensors | bash
+sudo sh -c "curl -kL dexterindustries.com/update_sensors | bash"
+```
+
+2. For installing the python packages of the `DI_Sensors` without root privileges (except any other settings that can come with), use the following command:
+```
+curl -kL dexterindustries.com/update_sensors | bash
 ```
 The same command can be used for updating the `DI_Sensors` to the latest version.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-DI_Sensors
+DI_Sensors [![Documentation Status](http://readthedocs.org/projects/di-sensors/badge/?version=master)](http://di-sensors.readthedocs.io/en/master/?badge=master)
 ============
 Dexter Industries Sensors
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -51,7 +51,7 @@ In order to install the DI-Sensors package you need to open up a terminal on you
 
 .. code-block:: bash
 
-   sudo curl -kL dexterindustries.com/update_sensors | bash
+   sudo sh -c "curl -kL dexterindustries.com/update_sensors | bash"
 
 Enter the command and follow the instructions given, if provided.
 This command can also be used for updating the package with the latest changes.


### PR DESCRIPTION
With this PR, we should be able to install the python packages of the DI_Sensors repo with or without `su` permissions, depending on whether we use `sudo` or not when installing. 

This should affect just the python packages contained in our repository whilst everything else is untouched - meaning that other things that can get installed will use `su` permissions, regardless. There were reasons not to touch everything else.

This has been tested on my own machine and it works. Other tests are still required, such as on `DexterOS` or `Raspbian For Robots`.

Last thing, this PR (like the many others I've already filed) should get us rid off the use of `sudo`s, at least partially, if not fully. The generally accepted method is to not use root permissions , unless specified by the user. 
Also, I need these changes so I can keep working on DexterOS `v2.0.0`.