### PR TITLE
Bug/distance sensor infinity

### DIFF
--- a/Python/di_sensors/distance_sensor.py
+++ b/Python/di_sensors/distance_sensor.py
@@ -70,7 +70,7 @@ class DistanceSensor(object):
         """
         Read the detected range with a single measurement. This is less precise/fast than its counterpart :py:meth:`~di_sensors.distance_sensor.DistanceSensor.read_range_continuous`, but it's easier to use.
 
-        :param boolean safe_infinity = True: As sometimes the distance sensor returns a small value when there's nothing in front of it, we need to poll again and again to confirm the presence of an obstacle. Setting safe_infinity to False will avoid that extra polling.
+        :param boolean safe_infinity = True: As sometimes the distance sensor returns a small value when there's nothing in front of it, we need to poll again and again to confirm the presence of an obstacle. Setting ``safe_infinity`` to ``False`` will avoid that extra polling.
 
         :returns: The detected range of the sensor as measured in millimeters. The range can go up to 2 meters.
         :rtype: int


### PR DESCRIPTION
In read_range_single, if an obstacle is detected, let's poll again up to 3 times to ensure that we're not dealing with a false reading that should have been an infinity reading.
This avoids ghost detection. 
For advanced users, this extra polling could be turned off by using the safe_infinity parameter set to False. 