### PR TITLE
Fix/freedom for distance sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 docs/build/*
 *.pyc
 *.json
+.vscode/.ropeproject/config.py
+.vscode/.ropeproject/objectdb

--- a/Python/di_sensors/VL53L0X.py
+++ b/Python/di_sensors/VL53L0X.py
@@ -870,7 +870,7 @@ class VL53L0X(object):
         self.start_timeout()
         while (self.i2c_bus.read_8(SYSRANGE_START) & 0x01):
             if self.check_timeout_expired():
-                self.did_timeout = true
+                self.did_timeout = True
                 raise IOError("read_range_single_millimeters timeout")
         return self.read_range_continuous_millimeters()
 

--- a/Python/di_sensors/VL53L0X.py
+++ b/Python/di_sensors/VL53L0X.py
@@ -361,13 +361,14 @@ class VL53L0X(object):
 
         return True
 
-    def set_signal_rate_limit(self, limit_Mcps):
-        if (limit_Mcps < 0 or limit_Mcps > 511.99):
-            return False
+# duplicate method
+    # def set_signal_rate_limit(self, limit_Mcps):
+    #     if (limit_Mcps < 0 or limit_Mcps > 511.99):
+    #         return False
 
-        # Q9.7 fixed point format (9 integer bits, 7 fractional bits)
-        self.i2c_bus.write_reg_16(FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT, int(limit_Mcps * (1 << 7)))
-        return True
+    #     # Q9.7 fixed point format (9 integer bits, 7 fractional bits)
+    #     self.i2c_bus.write_reg_16(FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT, int(limit_Mcps * (1 << 7)))
+    #     return True
 
     # Get reference SPAD (single photon avalanche diode) count and type
     # based on VL53L0X_get_info_from_device(),

--- a/Python/di_sensors/VL53L0X.py
+++ b/Python/di_sensors/VL53L0X.py
@@ -531,7 +531,7 @@ class VL53L0X(object):
     #always stored in a uint16_t.
     def decode_timeout(self, reg_val):
         # format: "(LSByte * 2^MSByte) + 1"
-        return ((reg_val & 0x00FF) << ((reg_val & 0xFF00) >> 8)) + 1;
+        return ((reg_val & 0x00FF) << ((reg_val & 0xFF00) >> 8)) + 1
 
     # Set the measurement timing budget in microseconds, which is the time allowed
     # for one measurement the ST API and this library take care of splitting the
@@ -856,15 +856,15 @@ class VL53L0X(object):
     # millimeters
     # based on VL53L0X_PerformSingleRangingMeasurement()
     def read_range_single_millimeters(self):
-        self.i2c_bus.write_reg_8(0x80, 0x01);
-        self.i2c_bus.write_reg_8(0xFF, 0x01);
-        self.i2c_bus.write_reg_8(0x00, 0x00);
-        self.i2c_bus.write_reg_8(0x91, self.stop_variable);
-        self.i2c_bus.write_reg_8(0x00, 0x01);
-        self.i2c_bus.write_reg_8(0xFF, 0x00);
-        self.i2c_bus.write_reg_8(0x80, 0x00);
+        self.i2c_bus.write_reg_8(0x80, 0x01)
+        self.i2c_bus.write_reg_8(0xFF, 0x01)
+        self.i2c_bus.write_reg_8(0x00, 0x00)
+        self.i2c_bus.write_reg_8(0x91, self.stop_variable)
+        self.i2c_bus.write_reg_8(0x00, 0x01)
+        self.i2c_bus.write_reg_8(0xFF, 0x00)
+        self.i2c_bus.write_reg_8(0x80, 0x00)
 
-        self.i2c_bus.write_reg_8(SYSRANGE_START, 0x01);
+        self.i2c_bus.write_reg_8(SYSRANGE_START, 0x01)
 
         # "Wait until start bit has been cleared"
         self.start_timeout()

--- a/Python/di_sensors/easy_distance_sensor.py
+++ b/Python/di_sensors/easy_distance_sensor.py
@@ -39,6 +39,8 @@ class EasyDistanceSensor(distance_sensor.DistanceSensor):
                             "AD1" : "GPG3_AD1",
                             "AD2" : "GPG3_AD2",
                             "RPI_1SW": "RPI_1SW",
+                            "RPI_1" : "RPI_1",
+                            "RPI_1HW" : "RPI_1",   # doesn't really exist but can be a reflex for some users as we do have RPI_1SW
                             "GPG3_AD1": "GPG3_AD1",
                             "GPG3_AD2": "GPG3_AD2"}
 

--- a/Python/di_sensors/easy_distance_sensor.py
+++ b/Python/di_sensors/easy_distance_sensor.py
@@ -19,10 +19,11 @@ class EasyDistanceSensor(distance_sensor.DistanceSensor):
     Apart from this difference, there may also be functions that are more user-friendly than the latter.
 
     """
-    def __init__(self, use_mutex=False):
+    def __init__(self, port="I2C", use_mutex=False):
         """
         Creates a :py:class:`~easygopigo3.EasyDistanceSensor` object which can be used for interfacing with a `distance sensor`_.
 
+        :param string bus = ``"I2C"``: the bus for the sensor. For the GoPiGo3, options also include ``"GPG3_AD1"`` and ``"GPG3_AD2"``.
         :param bool use_mutex = False: When using multiple threads/processes that access the same resource/device, mutexes should be enabled. Check the :ref:`hardware specs <hardware-interface-section>` for more information about the ports.
         :raises ~exceptions.OSError: When the distance sensor is not connected to the designated bus/port, where in this case it must be ``"I2C"``. Most probably, this means the distance sensor is not connected at all.
 
@@ -32,9 +33,25 @@ class EasyDistanceSensor(distance_sensor.DistanceSensor):
         self.descriptor = "Distance Sensor"
         self.use_mutex = use_mutex
 
+        # let's be kind to the user who may get confused between ports and buses 
+        # let's allow for all of them
+        possible_ports = { "I2C" : "RPI_1SW",
+                            "AD1" : "GPG3_AD1",
+                            "AD2" : "GPG3_AD2",
+                            "RPI_1SW": "RPI_1SW",
+                            "GPG3_AD1": "GPG3_AD1",
+                            "GPG3_AD2": "GPG3_AD2"}
+
+        port = port.upper() # force to uppercase
+        # switch quietly to default value if we receive gibberish
+        if port in possible_ports.keys():
+            bus = possible_ports[port]
+        else:
+            bus = "RPI_1SW"
+
         ifMutexAcquire(self.use_mutex)
         try:
-            distance_sensor.DistanceSensor.__init__(self)
+            distance_sensor.DistanceSensor.__init__(self, bus=bus)
         except Exception as e:
             print("Distance Sensor init: {}".format(e))
             raise


### PR DESCRIPTION
easy_distance_sensor now allows for RPI_1SW (by default!) and also GPG3_AD1, GPG3_AD2 and RPI_1

Fix some minor python issues in VL53L0X.py as VS code was complaining.
