### PR TITLE
Scratch Line Follower : some cleanup

### DIFF
--- a/Install/update_functions.sh
+++ b/Install/update_functions.sh
@@ -12,7 +12,7 @@ configure_line_follower(){
     delete_file $PIHOME/Desktop/line_follower_calibration.desktop
     sudo cp $PIHOME/$DEXTER/DI_Sensors/Python/di_sensors/line_follower_calibration/line_follower_calibration.desktop $PIHOME/Desktop/
     sudo chmod +x $PIHOME/Desktop/line_follower_calibration.desktop
-    sudo chmod +x $PIHOME/Dexter/DI_Sensors/Python/di_sensors/line_sensor_calibration_gui.py
+    sudo chmod +x $PIHOME/Dexter/DI_Sensors/Python/di_sensors/line_follower_calibration/line_sensor_calibration_gui.py
   fi
 
   # if the configuration files exist in the home directory

--- a/Python/di_sensors/easy_line_follower.py
+++ b/Python/di_sensors/easy_line_follower.py
@@ -296,13 +296,13 @@ class EasyLineFollower(object):
         """
         Same as calling :py:meth:`~di_sensors.easy_line_follower.EasyLineFollower.read` method like ``read("weighted-avg")``.
 
-        :rtype: float/int ie float (for 0->1) or int (for 2 or 3)
-        :returns: Range is between **0.0** and **1.0**. For **<0.5**, the black line is on the right of the line follower, otherwise it's on the left. 
-            **0.5** suggests the black line is in the middle. It can also return **2** if it's all black, or **3** for only white.
+        :rtype: int 
+        :returns: Range is between **0** and **10**. For **<5**, the black line is on the right of the line follower, otherwise it's on the left. 
+            **5** suggests the black line is in the middle. It can also return **20** if it's all black, or **30** for only white.
         :raises: Check :py:meth:`~di_sensors.easy_line_follower.EasyLineFollower.read`.
         """
         weights = self.read(representation="weighted-avg") 
-        return weights[0] if weights[1] == 0 else weights[1] + 1
+        return round(weights[0]*10,0) if weights[1] == 0 else round(weights[1] + 1,0)*10
 
     def get_white_calibration(self):
         self.set_calibration('white')

--- a/Python/di_sensors/easy_line_follower.py
+++ b/Python/di_sensors/easy_line_follower.py
@@ -308,7 +308,7 @@ class EasyLineFollower(object):
         :raises: Check :py:meth:`~di_sensors.easy_line_follower.EasyLineFollower.read`.
         """
         weights = self.read(representation="weighted-avg") 
-        return round(weights[0]*10,0) if weights[1] == 0 else round(weights[1] + 1,0)*10
+        return round(weights[0] * 10, 0) if weights[1] == 0 else round(weights[1] + 1, 0) * 10
 
     def get_white_calibration(self):
         self.set_calibration('white')

--- a/Python/di_sensors/easy_line_follower.py
+++ b/Python/di_sensors/easy_line_follower.py
@@ -211,8 +211,10 @@ class EasyLineFollower(object):
             Returns a 2-element tuple. The first element is an estimated position of the line. 
             
             The estimate is computed using a weighted average of each sensor value (regardless of which line follower sensor is used), 
-            so that if the black line is on the left of the line follower, the returned value will be in the **0.0-0.5** range and if it's on the right, 
-            it's in the **0.5-1.0** range, thus making **0.5** the center point of the black line. Keep in mind that the sensor's orientation is determined by the order
+            so that if the black line is on the left of the line follower, the returned value will be in the **0.0-0.5** range and 
+            if it's on the right, it's in the **0.5-1.0** range, 
+            thus making **0.5** the center point of the black line. 
+            Keep in mind that the sensor's orientation is determined by the order
             of the returned sensor values and not by how the sensor is positioned on the robot. 
             Check :py:meth:`~di_sensors.line_follower.LineFollower.read_sensors` and :py:meth:`~di_sensors.line_follower.LineFollowerRed.read_sensors` methods to see
             how the values are returned. 
@@ -297,8 +299,12 @@ class EasyLineFollower(object):
         Same as calling :py:meth:`~di_sensors.easy_line_follower.EasyLineFollower.read` method like ``read("weighted-avg")``.
 
         :rtype: int 
-        :returns: Range is between **0** and **10**. For **<5**, the black line is on the right of the line follower, otherwise it's on the left. 
-            **5** suggests the black line is in the middle. It can also return **20** if it's all black, or **30** for only white.
+        :returns: Range is between **0** and **30**. 
+            When following a line the values will be between 0 and 10.
+            For values smaller than **5**, the black line is on the left of the robot, 
+            and for values bigger than **5** but no more than **10** the line is to the right. 
+            **5** suggests the black line is in the middle. 
+            It can also return **20** if it's all black, or **30** for all white.
         :raises: Check :py:meth:`~di_sensors.easy_line_follower.EasyLineFollower.read`.
         """
         weights = self.read(representation="weighted-avg") 

--- a/Scratch/diSensorsScratch.py
+++ b/Scratch/diSensorsScratch.py
@@ -93,7 +93,7 @@ def handleDiSensors(msg):
     if regObj == None:
         print ("DI Sensors: Command %s is not recognized" % (msg))
         return None
-    else:
+    # else:
         # if en_debug:
             # print ("matching done")
     

--- a/Scratch/diSensorsScratch.py
+++ b/Scratch/diSensorsScratch.py
@@ -94,11 +94,11 @@ def handleDiSensors(msg):
         print ("DI Sensors: Command %s is not recognized" % (msg))
         return None
     else:
-        if en_debug:
-            print ("matching done")
+        # if en_debug:
+            # print ("matching done")
     
-    if regObj:
-        print (regObj.groups())
+    # if regObj:
+    #     print (regObj.groups())
 
         # handling a light color sensor
         port = regObj.group(1)  # port nb goes from 0 to 3 from now on
@@ -202,8 +202,9 @@ def handleDiSensors(msg):
         if scratch_linefollower:
             line_values = scratch_linefollower.read()
             estimated_position, lost_line = scratch_linefollower._weighted_avg(line_values)
-            retdict["LINE position"] = scratch_linefollower._position(estimated_position, lost_line )
+            retdict["line position"] = scratch_linefollower._position(estimated_position, lost_line )
             retdict["line sensors bw"] = scratch_linefollower._bivariate_str(line_values)
+            retdict["line number"] = scratch_linefollower.position_val()
             retdict["line sensor 1"] = line_values[0]
             retdict["line sensor 2"] = line_values[1]
             retdict["line sensor 3"] = line_values[2]
@@ -211,9 +212,9 @@ def handleDiSensors(msg):
             retdict["line sensor 5"] = line_values[4]
             if len(line_values) == 6:
                 retdict["line sensor 6"] = line_values[5]
-            retdict["LINE status"] = "ok"
+            retdict["line status"] = "ok"
         else:
-            retdict["LINE status"] = "line follower not found"
+            retdict["line status"] = "line follower not found"
 
     return (retdict)
 

--- a/Scratch/diSensorsScratch.py
+++ b/Scratch/diSensorsScratch.py
@@ -97,7 +97,7 @@ def handleDiSensors(msg):
         # if en_debug:
             # print ("matching done")
     
-    # if regObj:
+    if regObj:
     #     print (regObj.groups())
 
         # handling a light color sensor


### PR DESCRIPTION
1. Made the sensor names more consistent (lower caps)

2. Introduced "line number" for kids who want a bit more precise control than just left and right

3. Made position_val() always return an int for the kids who are not comfortable with decimals. 0 to 10 for a line position, 20 for all black and 30 for all white.

4. Remove extra print statements.
